### PR TITLE
Fix pipeline publishing and bump version to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spinal-obs-node",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "WithSpinal cost-aware OpenTelemetry SDK for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR fixes the npm publishing pipeline issues and bumps the package version to 1.0.7. The pipeline now properly checks if versions exist before publishing and should work correctly for future releases.