### PR TITLE
Test npm token authentication with version 1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spinal-obs-node",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "WithSpinal cost-aware OpenTelemetry SDK for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR tests the new npm automation token authentication. Version bumped to 1.0.11 to test the pipeline with the updated NPM_TOKEN secret that has proper publish permissions.