### PR TITLE
Test fresh npm token after deletion/recreation - version 1.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spinal-obs-node",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "WithSpinal cost-aware OpenTelemetry SDK for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR tests the npm token after completely deleting and recreating the NPM_TOKEN secret. This should resolve any caching issues that might have been causing the wrong token to be used.