### PR TITLE
chore: bump version to 1.0.19 for atomic append operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinal-obs-node",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "WithSpinal cost-aware OpenTelemetry SDK for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump to 1.0.19 including atomic append operation to avoid TOCTOU race conditions. All tests passing.